### PR TITLE
Feature/idempotente

### DIFF
--- a/actions/create-argocd-app/action.yml
+++ b/actions/create-argocd-app/action.yml
@@ -150,7 +150,8 @@ runs:
             --project ${{ inputs.app_project_name }} \
             --sync-policy automated \
             --grpc-web \
-            --insecure"
+            --insecure \
+            --upsert"
 
           IFS=',' read -ra S_OPTS <<< "${{ inputs.sync_options }}"
           for opt in "${S_OPTS[@]}"; do

--- a/actions/create-argocd-app/action.yml
+++ b/actions/create-argocd-app/action.yml
@@ -137,7 +137,7 @@ runs:
     - name: Check if Argo CD application exists and create if not
       shell: bash
       run: |
-        if ! argocd app get ${{inputs.app_name}} --app-namespace ${{ inputs.app_dest_namespace }} &> /dev/null; then   
+        if ! argocd app get ${{inputs.app_name}} --app-namespace ${{ inputs.app_dest_namespace }} ; then   
 
           # Initializer la commande de création de l'application
           echo "Argo CD application '${{inputs.app_name}}' does not exist. Creating it..."

--- a/actions/remove-argocd-app/action.yml
+++ b/actions/remove-argocd-app/action.yml
@@ -96,7 +96,7 @@ runs:
 
         echo "Vérification de l'existence de l'application Argo CD : $APP_NAME"
 
-        if argocd app get $APP_NAME --app-namespace $APP_NAMESPACE > /dev/null 2>&1; then
+        if argocd app get $APP_NAME --app-namespace $APP_NAMESPACE ; then
           echo "Application '$APP_NAME' trouvée. Suppression en cours ..."
           argocd app delete "$APP_NAME" \
             --app-namespace "$APP_NAMESPACE" \


### PR DESCRIPTION
Implementation de deux features: 

- inclusion du paramètre --upsert dans la commande argo create app, pour permettre d'exécuter la commande plusieurs fois. Si l'application existe déjà, elle fera l'update des parties différentes du status actuel. Opération idempotente; 

- enlever le statement &> /dev/null en fin de la commande `if ! argocd app get ${{inputs.app_name}} `; ce statement directionne la sortie de la commande au device /dev/null, ce qui fait que les messages après exécution, y compris les erreurs, soient invisibles dans le workflow. On ne pouvait pas voir des erreurs d'exécution de cette commande à cause de ce statement. 