### PR TITLE
Permettre la suppression des PVCs lors de la suppression de l'infrastructure

### DIFF
--- a/actions/remove-argocd-app/README.md
+++ b/actions/remove-argocd-app/README.md
@@ -23,6 +23,8 @@ Elle :
 - installe et configure le CLI ArgoCD si nécessaire ;
 - se connecte à Argo CD via utilisateur/mot de passe ;
 - vérifie que le projet existe (sinon interrompt proprement) ;
+- peut cibler un objet `Application` Argo CD dans un namespace applicatif Argo CD optionnel ;
+- peut supprimer explicitement les PVC protégés par `helm.sh/resource-policy: keep` ou `argocd.argoproj.io/sync-options: Delete=false` ;
 - supprime l'application ArgoCD si elle existe ;
 - utilise la cascade de suppression pour nettoyer proprement les ressources.
 
@@ -46,7 +48,9 @@ Elle :
 |argocd_password|Mot de passe ArgoCD|✅|—|
 |app_project_name|Projet ArgoCD contenant l'application. Le projet devrait déjà exister.|✅|—|
 |app_name|Nom de l'application ArgoCD à supprimer|✅|—|
-|app_dest_namespace|Namespace de l'application ArgoCD|❗|defaultApp|
+|app_dest_namespace|Namespace Kubernetes de destination de l'application|❗|defaultApp|
+|argocd_application_namespace|Namespace de l'objet `Application` Argo CD. Laisser vide pour utiliser le namespace Argo CD par défaut.|❗|—|
+|delete_persistent_volume_claims|Supprime explicitement les PVC de l'application avant la suppression Argo CD. À réserver aux workflows de destruction complète.|❗|false|
 
 ## Comportement général
 
@@ -56,6 +60,7 @@ Elle :
 4. Si le projet n'existe pas, le workflow s'arrête proprement.
 5. Vérifie si l'application existe.
 6. Si elle existe :
+    - si `delete_persistent_volume_claims` vaut `true`, supprime explicitement les protections des PVC de l'application, incluant `keep` / `Delete=false`
     - exécute `argocd app delete` avec cascade
     - supprime proprement toutes les ressources associées
 7. Si elle n'existe pas, signale qu'il n'y a rien à supprimer.
@@ -81,6 +86,7 @@ jobs:
           app_project_name: demo-project
           app_name: demo-app
           app_dest_namespace: default
+          delete_persistent_volume_claims: "true"
 ```
 
 ## Exemple de workflow
@@ -109,6 +115,7 @@ jobs:
           app_project_name: my-project
           app_name: ${{ github.event.inputs.app_name }}
           app_dest_namespace: production
+          delete_persistent_volume_claims: "true"
 ```
 
 ## Dépendances

--- a/actions/remove-argocd-app/README.md
+++ b/actions/remove-argocd-app/README.md
@@ -49,7 +49,6 @@ Elle :
 |app_project_name|Projet ArgoCD contenant l'application. Le projet devrait déjà exister.|✅|—|
 |app_name|Nom de l'application ArgoCD à supprimer|✅|—|
 |app_dest_namespace|Namespace Kubernetes de destination de l'application|❗|defaultApp|
-|argocd_application_namespace|Namespace de l'objet `Application` Argo CD. Laisser vide pour utiliser le namespace Argo CD par défaut.|❗|—|
 |delete_persistent_volume_claims|Supprime explicitement les PVC de l'application avant la suppression Argo CD. À réserver aux workflows de destruction complète.|❗|false|
 
 ## Comportement général

--- a/actions/remove-argocd-app/action.yml
+++ b/actions/remove-argocd-app/action.yml
@@ -98,12 +98,11 @@ runs:
         APP_DEST_NAMESPACE="${{ inputs.app_dest_namespace }}"
         APP_PROJECT="${{ inputs.app_project_name }}"
         DELETE_PVC="${{ inputs.delete_persistent_volume_claims }}"
-        APP_NAMESPACE_ARGS=()
         APP_LABEL="$APP_NAME"
         
         echo "Vérification de l'existence de l'application Argo CD : $APP_LABEL"
 
-        if APP_GET_OUTPUT="$(argocd app get "$APP_NAME" "${APP_NAMESPACE_ARGS[@]}" --grpc-web 2>&1)" ; then
+        if APP_GET_OUTPUT="$(argocd app get "$APP_NAME" --grpc-web 2>&1)" ; then
           printf '%s\n' "$APP_GET_OUTPUT"
           echo "Application '$APP_LABEL' trouvée. Suppression en cours ..."
 
@@ -111,7 +110,6 @@ runs:
             echo "Suppression explicite des PVC de l'application '$APP_LABEL' dans le namespace Kubernetes '$APP_DEST_NAMESPACE' ..."
 
             argocd app patch-resource "$APP_NAME" \
-              "${APP_NAMESPACE_ARGS[@]}" \
               --project "$APP_PROJECT" \
               --kind PersistentVolumeClaim \
               --namespace "$APP_DEST_NAMESPACE" \
@@ -123,7 +121,6 @@ runs:
           fi
 
           argocd app delete "$APP_NAME" \
-            "${APP_NAMESPACE_ARGS[@]}" \
             --cascade --yes --grpc-web
 
           echo "Application '$APP_LABEL' supprimée avec succès"

--- a/actions/remove-argocd-app/action.yml
+++ b/actions/remove-argocd-app/action.yml
@@ -23,9 +23,9 @@ inputs:
   app_dest_namespace: 
     description: "Namespace Kubernetes de destination de l'application"
     default: "defaultApp"
-  argocd_application_namespace:
-    description: "Namespace de l'objet Application Argo CD. Laisser vide pour le namespace Argo CD par défaut."
-    default: ""
+  # argocd_application_namespace:
+  #   description: "Namespace de l'objet Application Argo CD. Laisser vide pour le namespace Argo CD par défaut."
+  #   default: ""
   delete_persistent_volume_claims:
     description: "Supprimer explicitement les PVC de l'application avant la suppression Argo CD"
     default: "false"
@@ -99,16 +99,16 @@ runs:
 
         APP_NAME="${{ inputs.app_name }}"
         APP_DEST_NAMESPACE="${{ inputs.app_dest_namespace }}"
-        ARGOCD_APPLICATION_NAMESPACE="${{ inputs.argocd_application_namespace }}"
+        # ARGOCD_APPLICATION_NAMESPACE="${{ inputs.argocd_application_namespace }}"
         APP_PROJECT="${{ inputs.app_project_name }}"
         DELETE_PVC="${{ inputs.delete_persistent_volume_claims }}"
 
         APP_NAMESPACE_ARGS=()
         APP_LABEL="$APP_NAME"
-        if [ -n "$ARGOCD_APPLICATION_NAMESPACE" ]; then
-          APP_NAMESPACE_ARGS=(--app-namespace "$ARGOCD_APPLICATION_NAMESPACE")
-          APP_LABEL="$ARGOCD_APPLICATION_NAMESPACE/$APP_NAME"
-        fi
+        # if [ -n "$ARGOCD_APPLICATION_NAMESPACE" ]; then
+        #   APP_NAMESPACE_ARGS=(--app-namespace "$ARGOCD_APPLICATION_NAMESPACE")
+        #   APP_LABEL="$ARGOCD_APPLICATION_NAMESPACE/$APP_NAME"
+        # fi
 
         echo "Vérification de l'existence de l'application Argo CD : $APP_LABEL"
 

--- a/actions/remove-argocd-app/action.yml
+++ b/actions/remove-argocd-app/action.yml
@@ -23,6 +23,9 @@ inputs:
   app_dest_namespace: 
     description: "Espace de destination du projet Argo CD"
     default: "defaultApp"
+  delete_persistent_volume_claims:
+    description: "Supprimer explicitement les PVC de l'application avant la suppression Argo CD"
+    default: "false"
 
 runs:
   using: "composite"
@@ -93,11 +96,28 @@ runs:
 
         APP_NAME="${{ inputs.app_name }}"
         APP_NAMESPACE="${{ inputs.app_dest_namespace }}"
+        APP_PROJECT="${{ inputs.app_project_name }}"
+        DELETE_PVC="${{ inputs.delete_persistent_volume_claims }}"
 
         echo "Vérification de l'existence de l'application Argo CD : $APP_NAME"
 
         if argocd app get $APP_NAME --app-namespace $APP_NAMESPACE ; then
           echo "Application '$APP_NAME' trouvée. Suppression en cours ..."
+
+          if [ "$DELETE_PVC" = "true" ]; then
+            echo "Suppression explicite des PVC de l'application '$APP_NAME' dans le namespace '$APP_NAMESPACE' ..."
+
+            argocd app patch-resource "$APP_NAME" \
+              --project "$APP_PROJECT" \
+              --kind PersistentVolumeClaim \
+              --namespace "$APP_NAMESPACE" \
+              --all \
+              --patch '{"metadata":{"annotations":{"helm.sh/resource-policy":null,"argocd.argoproj.io/sync-options":null}}}' \
+              --patch-type application/merge-patch+json \
+              --grpc-web || true
+
+          fi
+
           argocd app delete "$APP_NAME" \
             --app-namespace "$APP_NAMESPACE" \
             --cascade --yes --grpc-web

--- a/actions/remove-argocd-app/action.yml
+++ b/actions/remove-argocd-app/action.yml
@@ -21,8 +21,11 @@ inputs:
     description: "Le nom de l'application"
     required: true
   app_dest_namespace: 
-    description: "Espace de destination du projet Argo CD"
+    description: "Namespace Kubernetes de destination de l'application"
     default: "defaultApp"
+  argocd_application_namespace:
+    description: "Namespace de l'objet Application Argo CD. Laisser vide pour le namespace Argo CD par défaut."
+    default: ""
   delete_persistent_volume_claims:
     description: "Supprimer explicitement les PVC de l'application avant la suppression Argo CD"
     default: "false"
@@ -95,22 +98,32 @@ runs:
         set -e
 
         APP_NAME="${{ inputs.app_name }}"
-        APP_NAMESPACE="${{ inputs.app_dest_namespace }}"
+        APP_DEST_NAMESPACE="${{ inputs.app_dest_namespace }}"
+        ARGOCD_APPLICATION_NAMESPACE="${{ inputs.argocd_application_namespace }}"
         APP_PROJECT="${{ inputs.app_project_name }}"
         DELETE_PVC="${{ inputs.delete_persistent_volume_claims }}"
 
-        echo "Vérification de l'existence de l'application Argo CD : $APP_NAME"
+        APP_NAMESPACE_ARGS=()
+        APP_LABEL="$APP_NAME"
+        if [ -n "$ARGOCD_APPLICATION_NAMESPACE" ]; then
+          APP_NAMESPACE_ARGS=(--app-namespace "$ARGOCD_APPLICATION_NAMESPACE")
+          APP_LABEL="$ARGOCD_APPLICATION_NAMESPACE/$APP_NAME"
+        fi
 
-        if argocd app get $APP_NAME --app-namespace $APP_NAMESPACE ; then
-          echo "Application '$APP_NAME' trouvée. Suppression en cours ..."
+        echo "Vérification de l'existence de l'application Argo CD : $APP_LABEL"
+
+        if APP_GET_OUTPUT="$(argocd app get "$APP_NAME" "${APP_NAMESPACE_ARGS[@]}" --grpc-web 2>&1)" ; then
+          printf '%s\n' "$APP_GET_OUTPUT"
+          echo "Application '$APP_LABEL' trouvée. Suppression en cours ..."
 
           if [ "$DELETE_PVC" = "true" ]; then
-            echo "Suppression explicite des PVC de l'application '$APP_NAME' dans le namespace '$APP_NAMESPACE' ..."
+            echo "Suppression explicite des PVC de l'application '$APP_LABEL' dans le namespace Kubernetes '$APP_DEST_NAMESPACE' ..."
 
             argocd app patch-resource "$APP_NAME" \
+              "${APP_NAMESPACE_ARGS[@]}" \
               --project "$APP_PROJECT" \
               --kind PersistentVolumeClaim \
-              --namespace "$APP_NAMESPACE" \
+              --namespace "$APP_DEST_NAMESPACE" \
               --all \
               --patch '{"metadata":{"annotations":{"helm.sh/resource-policy":null,"argocd.argoproj.io/sync-options":null}}}' \
               --patch-type application/merge-patch+json \
@@ -119,10 +132,19 @@ runs:
           fi
 
           argocd app delete "$APP_NAME" \
-            --app-namespace "$APP_NAMESPACE" \
+            "${APP_NAMESPACE_ARGS[@]}" \
             --cascade --yes --grpc-web
 
-          echo "Application '$APP_NAME' supprimée avec succès"
+          echo "Application '$APP_LABEL' supprimée avec succès"
         else
-          echo "Application '$APP_NAME' n'existe pas. Rien à supprimer."
-        fi      
+          APP_GET_STATUS=$?
+          printf '%s\n' "$APP_GET_OUTPUT"
+
+          if printf '%s\n' "$APP_GET_OUTPUT" | grep -Eiq "code = NotFound|not found|does not exist|n.existe pas"; then
+            echo "Application '$APP_LABEL' n'existe pas. Rien à supprimer."
+            exit 0
+          fi
+
+          echo "::error::Impossible de lire l'application Argo CD '$APP_LABEL'."
+          exit "$APP_GET_STATUS"
+        fi

--- a/actions/remove-argocd-app/action.yml
+++ b/actions/remove-argocd-app/action.yml
@@ -23,9 +23,6 @@ inputs:
   app_dest_namespace: 
     description: "Namespace Kubernetes de destination de l'application"
     default: "defaultApp"
-  # argocd_application_namespace:
-  #   description: "Namespace de l'objet Application Argo CD. Laisser vide pour le namespace Argo CD par défaut."
-  #   default: ""
   delete_persistent_volume_claims:
     description: "Supprimer explicitement les PVC de l'application avant la suppression Argo CD"
     default: "false"
@@ -99,17 +96,11 @@ runs:
 
         APP_NAME="${{ inputs.app_name }}"
         APP_DEST_NAMESPACE="${{ inputs.app_dest_namespace }}"
-        # ARGOCD_APPLICATION_NAMESPACE="${{ inputs.argocd_application_namespace }}"
         APP_PROJECT="${{ inputs.app_project_name }}"
         DELETE_PVC="${{ inputs.delete_persistent_volume_claims }}"
-
         APP_NAMESPACE_ARGS=()
         APP_LABEL="$APP_NAME"
-        # if [ -n "$ARGOCD_APPLICATION_NAMESPACE" ]; then
-        #   APP_NAMESPACE_ARGS=(--app-namespace "$ARGOCD_APPLICATION_NAMESPACE")
-        #   APP_LABEL="$ARGOCD_APPLICATION_NAMESPACE/$APP_NAME"
-        # fi
-
+        
         echo "Vérification de l'existence de l'application Argo CD : $APP_LABEL"
 
         if APP_GET_OUTPUT="$(argocd app get "$APP_NAME" "${APP_NAMESPACE_ARGS[@]}" --grpc-web 2>&1)" ; then


### PR DESCRIPTION
## 🚀 Description

Améliore l'action de suppression d'applications Argo CD. Elle introduit deux fonctionnalités majeures :
1.  **Gestion des PVC persistants** : Possibilité de supprimer les PVC qui sont normalement protégés par des politiques de rétention.
2.  **Support des Namespaces d'Application** : Support des instances Argo CD configurées en mode multi-tenant (où les objets `Application` ne sont pas dans le namespace par défaut).

## ✨ Nouvelles fonctionnalités

*   **🗑️ Nettoyage forcé des PVC** : Ajout de l'input `delete_persistent_volume_claims`. Si activé, l'action retire les annotations `helm.sh/resource-policy: keep` et `argocd.argoproj.io/sync-options: Delete=false` des PVC avant la suppression.
*   **📂 Namespacing Argo CD** : Ajout de l'input `argocd_application_namespace` pour cibler l'objet `Application` dans un namespace spécifique (via le flag `--app-namespace`).
*   **🔍 Robustesse accrue** : Amélioration de la détection d'existence de l'application pour éviter de faire échouer le pipeline si l'application a déjà été supprimée manuellement.

## 📝 Détails des modifications

### GitHub Action Inputs
| Input | Description | Par défaut |
| :--- | :--- | :--- |
| `argocd_application_namespace` | Namespace de l'objet Application Argo CD | `""` |
| `delete_persistent_volume_claims` | Supprime explicitement les PVC avant la suppression de l'app | `"false"` |
| `app_dest_namespace` | Namespace Kubernetes de destination | `"defaultApp"` |

### Logique Script (`runs`)
- Implémentation de `argocd app patch-resource` pour modifier les PVC à la volée.
- Utilisation de `APP_NAMESPACE_ARGS` pour injecter dynamiquement le namespace dans les commandes CLI.
- Amélioration des logs pour différencier le namespace de l'objet ArgoCD et le namespace de destination Kubernetes.