### PR TITLE
Ajuster le script de suppression ArgoCD : suppression optionnelle des PVC et gestion plus robuste des erreurs

### DIFF
--- a/actions/remove-argocd-app/action.yml
+++ b/actions/remove-argocd-app/action.yml
@@ -90,6 +90,7 @@ runs:
         fi
 
     - name: Check if Argo CD application exists and remove if exists
+      if: steps.check_project.outputs.project_exists_exists == 'true'
       shell: bash
       run: |
         set -e

--- a/actions/remove-argocd-app/action.yml
+++ b/actions/remove-argocd-app/action.yml
@@ -138,6 +138,17 @@ runs:
             exit 0
           fi
 
+          # If output indicates permission issues, fail with an actionable message
+          if printf '%s\n' "$APP_GET_OUTPUT" | grep -Eiq "code = PermissionDenied|permission denied|PermissionDenied"; then
+            echo "::error::Permission denied while reading Argo CD application '$APP_LABEL'."
+            echo "Vérifiez :"
+            echo "  - Les identifiants (${ { inputs.argocd_username }}) / token fournis sont corrects"
+            echo "  - Le compte a les droits RBAC nécessaires pour lire/effacer l'application (applications.get / applications.delete)"
+            echo "  - La configuration du serveur argocd (TLS / grpc-web / --insecure) est correcte"
+            echo "Exemple: retenter 'argocd login' puis 'argocd app get $APP_NAME' localement pour reproduire."
+            exit 2
+          fi
+
           # Otherwise treat as a real error
           echo "::error::Impossible de lire l'application Argo CD '$APP_LABEL'."
           exit $APP_GET_EXIT

--- a/actions/remove-argocd-app/action.yml
+++ b/actions/remove-argocd-app/action.yml
@@ -92,7 +92,7 @@ runs:
       if: steps.check_project.outputs.project_exists == 'true'
       shell: bash
       run: |
-        set -e
+        set -euo pipefail
 
         APP_NAME="${{ inputs.app_name }}"
         APP_DEST_NAMESPACE="${{ inputs.app_dest_namespace }}"
@@ -102,7 +102,13 @@ runs:
         
         echo "Vérification de l'existence de l'application Argo CD : $APP_LABEL"
 
-        if APP_GET_OUTPUT="$(argocd app get "$APP_NAME" --grpc-web 2>&1)" ; then
+        # allow the `argocd app get` to fail without terminating the whole script
+        set +e
+        APP_GET_OUTPUT="$(argocd app get "$APP_NAME" --grpc-web 2>&1)"
+        APP_GET_EXIT=$?
+        set -e
+
+        if [ $APP_GET_EXIT -eq 0 ]; then
           printf '%s\n' "$APP_GET_OUTPUT"
           echo "Application '$APP_LABEL' trouvée. Suppression en cours ..."
 
@@ -117,22 +123,22 @@ runs:
               --patch '{"metadata":{"annotations":{"helm.sh/resource-policy":null,"argocd.argoproj.io/sync-options":Delete=true}}}' \
               --patch-type application/merge-patch+json \
               --grpc-web || true
-
           fi
 
-          argocd app delete "$APP_NAME" \
-            --cascade --yes --grpc-web
-
+          # attempt deletion; propagate a real delete failure
+          argocd app delete "$APP_NAME" --cascade --yes --grpc-web
           echo "Application '$APP_LABEL' supprimée avec succès"
         else
-          APP_GET_STATUS=$?
+          # Print argocd output for debugging
           printf '%s\n' "$APP_GET_OUTPUT"
 
+          # If output indicates the app doesn't exist, succeed gracefully
           if printf '%s\n' "$APP_GET_OUTPUT" | grep -Eiq "code = NotFound|not found|does not exist|n.existe pas"; then
             echo "Application '$APP_LABEL' n'existe pas. Rien à supprimer."
             exit 0
           fi
 
+          # Otherwise treat as a real error
           echo "::error::Impossible de lire l'application Argo CD '$APP_LABEL'."
-          exit "$APP_GET_STATUS"
+          exit $APP_GET_EXIT
         fi

--- a/actions/remove-argocd-app/action.yml
+++ b/actions/remove-argocd-app/action.yml
@@ -79,18 +79,17 @@ runs:
           echo "project_exists=false" >> $GITHUB_OUTPUT
         fi 
     
-    - name: Quitter si le projet n'existe pas
+    - name: Print résultat de la vérification si le projet existe
       shell: bash
       run: |
         if ${{steps.check_project.outputs.project_exists == 'false'}}; then
           echo "Projet ${{inputs.app_project_name}} does not exist, exit workflow. Contactez l'administrateur de projets pour créer le projet"
-          exit 0
         else
           echo "Project ${{inputs.app_project_name}} exists, will continue"
         fi
 
     - name: Check if Argo CD application exists and remove if exists
-      if: steps.check_project.outputs.project_exists_exists == 'true'
+      if: steps.check_project.outputs.project_exists == 'true'
       shell: bash
       run: |
         set -e
@@ -115,7 +114,7 @@ runs:
               --kind PersistentVolumeClaim \
               --namespace "$APP_DEST_NAMESPACE" \
               --all \
-              --patch '{"metadata":{"annotations":{"helm.sh/resource-policy":null,"argocd.argoproj.io/sync-options":null}}}' \
+              --patch '{"metadata":{"annotations":{"helm.sh/resource-policy":null,"argocd.argoproj.io/sync-options":Delete=true}}}' \
               --patch-type application/merge-patch+json \
               --grpc-web || true
 

--- a/actions/remove-argocd-app/action.yml
+++ b/actions/remove-argocd-app/action.yml
@@ -104,7 +104,7 @@ runs:
 
         # allow the `argocd app get` to fail without terminating the whole script
         set +e
-        APP_GET_OUTPUT="$(argocd app get "$APP_NAME" --grpc-web 2>&1)"
+        APP_GET_OUTPUT="$(argocd app get "$APP_NAME" /dev/null 2>&1)"
         APP_GET_EXIT=$?
         set -e
 

--- a/actions/remove-argocd-app/action.yml
+++ b/actions/remove-argocd-app/action.yml
@@ -98,12 +98,14 @@ runs:
         APP_DEST_NAMESPACE="${{ inputs.app_dest_namespace }}"
         APP_PROJECT="${{ inputs.app_project_name }}"
         DELETE_PVC="${{ inputs.delete_persistent_volume_claims }}"
+        ARGOCD_USERNAME="${{ inputs.argocd_username }}"
         APP_LABEL="$APP_NAME"
         
         echo "Vérification de l'existence de l'application Argo CD : $APP_LABEL"
 
         # allow the `argocd app get` to fail without terminating the whole script
         set +e
+        APP_GET_STATUS=0
         APP_GET_OUTPUT="$(argocd app get "$APP_NAME" --grpc-web 2>&1)" || APP_GET_STATUS=$?
         APP_GET_STATUS=${APP_GET_STATUS:-0}
         set -e
@@ -142,7 +144,7 @@ runs:
           if printf '%s\n' "$APP_GET_OUTPUT" | grep -Eiq "code = PermissionDenied|permission denied|PermissionDenied"; then
             echo "::error::Permission denied while reading Argo CD application '$APP_LABEL'."
             echo "Vérifiez :"
-            echo "  - Les identifiants (${ { inputs.argocd_username }}) / token fournis sont corrects"
+            echo "  - Les identifiants ($$ARGOCD_USERNAME) / token fournis sont corrects"
             echo "  - Le compte a les droits RBAC nécessaires pour lire/effacer l'application (applications.get / applications.delete)"
             echo "  - La configuration du serveur argocd (TLS / grpc-web / --insecure) est correcte"
             echo "Exemple: retenter 'argocd login' puis 'argocd app get $APP_NAME' localement pour reproduire."
@@ -151,5 +153,5 @@ runs:
 
           # Otherwise treat as a real error
           echo "::error::Impossible de lire l'application Argo CD '$APP_LABEL'."
-          exit $APP_GET_EXIT
+          exit $APP_GET_STATUS
         fi

--- a/actions/remove-argocd-app/action.yml
+++ b/actions/remove-argocd-app/action.yml
@@ -104,11 +104,11 @@ runs:
 
         # allow the `argocd app get` to fail without terminating the whole script
         set +e
-        APP_GET_OUTPUT="$(argocd app get "$APP_NAME" /dev/null 2>&1)"
-        APP_GET_EXIT=$?
+        APP_GET_OUTPUT="$(argocd app get "$APP_NAME" --grpc-web 2>&1)" || APP_GET_STATUS=$?
+        APP_GET_STATUS=${APP_GET_STATUS:-0}
         set -e
 
-        if [ $APP_GET_EXIT -eq 0 ]; then
+        if [ $APP_GET_STATUS -eq 0 ]; then
           printf '%s\n' "$APP_GET_OUTPUT"
           echo "Application '$APP_LABEL' trouvée. Suppression en cours ..."
 


### PR DESCRIPTION
Ce PR modifie le script de suppression d'une application dans ArgoCD pour permettre la suppression optionnelle des PersistentVolumeClaims (PVC) lorsque nécessaire, et pour rendre la vérification de l'existence de l'application plus contrôlée (distinction entre "application introuvable" et autres erreurs). Attention : la gestion du cas “permission denied” renvoyé par la commande n'est pas encore traitée.